### PR TITLE
Improvements on makefile and other corrections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,31 @@
+.PHONY: check-mypy
+check-mypy:
+	@which mypy > /dev/null || (echo "mypy is not installed, please install it to continue" && false)
+
+.PHONY: check-yapf
+check-yapf:
+	@which yapf > /dev/null || (echo "yapf is not installed, please install it to continue" && false)
+
+.PHONY: check-flake8
+check-flake8:
+	@which flake8 > /dev/null || (echo "flake8 is not installed, please install it to continue" && false)
+
+.PHONY: check-isort
+check-isort:
+	@which isort > /dev/null || (echo "isort is not installed, please install it to continue" && false)
+
+.PHONY: check-bandit
+check-bandit:
+	@which bandit > /dev/null || (echo "bandit is not installed, please install it to continue" && false)
+
+.PHONY: check-pytest
+check-pytest:
+	@which pytest > /dev/null || (echo "pytest is not installed, please install it to continue" && false)
+
+.PHONY: check-docker
+check-docker:
+	@which docker > /dev/null || (echo "Docker is not installed, please install it to continue" && false)
+
 .PHONY: dist
 dist: wheel docker
 
@@ -5,27 +33,27 @@ dist: wheel docker
 code: check format lint sort bandit test
 
 .PHONY: check
-check:
+check: check-mypy
 	mypy pantos/client/cli
 
 .PHONY: format
-format:
+format: check-yapf
 	yapf --in-place --recursive pantos/client/cli tests
 
 .PHONY: lint
-lint:
+lint: check-flake8
 	flake8 pantos/client/cli tests
 
 .PHONY: sort
-sort:
+sort: check-isort
 	isort --force-single-line-imports pantos/client/cli tests
 
 .PHONY: bandit
-bandit:
+bandit: check-bandit
 	bandit -r pantos/client/cli tests --quiet --configfile=.bandit
 
 .PHONY: test
-test:
+test: check-pytest
 	python -m pytest tests
 
 .PHONY: coverage
@@ -44,7 +72,7 @@ dist/pantos_client_cli-$(PANTOS_CLIENT_CLI_VERSION)-py3-none-any.whl: environmen
 	rm pantos/pantos-client-library.conf
 
 .PHONY: docker
-docker: dist/pantos_client_cli-$(PANTOS_CLIENT_CLI_VERSION).docker
+docker: check-docker dist/pantos_client_cli-$(PANTOS_CLIENT_CLI_VERSION).docker
 
 dist/pantos_client_cli-$(PANTOS_CLIENT_CLI_VERSION).docker: environment-variables Dockerfile pantos/ pantos-client-cli.conf.$(PANTOS_CLIENT_CLI_ENVIRONMENT) pantos-client-library.conf.$(PANTOS_CLIENT_CLI_ENVIRONMENT) requirements.txt submodules/client-library/pantos/client/library/ submodules/common/pantos/common/
 	docker build -t pantosio/pantos-client --build-arg environment=$(PANTOS_CLIENT_CLI_ENVIRONMENT) .
@@ -60,7 +88,7 @@ uninstall:
 	python3 -m pip uninstall -y pantos-client-cli
 
 .PHONY: clean
-clean:
+clean: check-docker
 	rm -r -f build/
 	rm -r -f dist/
 	rm -r -f pantos_client_cli.egg-info/

--- a/Makefile
+++ b/Makefile
@@ -76,3 +76,22 @@ endif
 ifndef PANTOS_CLIENT_CLI_VERSION
 	$(error PANTOS_CLIENT_CLI_VERSION is undefined)
 endif
+
+.PHONY: help
+help:
+	@echo "Available targets:"
+	@echo "  dist       - Build both the wheel package and the Docker image."
+	@echo "  code       - Run checks, formatting, linting, sorting, security analysis, and tests."
+	@echo "  check      - Perform type checks on the code."
+	@echo "  format     - Format the codebase using yapf."
+	@echo "  lint       - Lint the codebase using flake8."
+	@echo "  sort       - Sort import statements using isort."
+	@echo "  bandit     - Perform security analysis using bandit."
+	@echo "  test       - Run tests using pytest."
+	@echo "  coverage   - Generate a test coverage report and remove the coverage file."
+	@echo "  wheel      - Build a wheel package for the project."
+	@echo "  docker     - Build a Docker image for the project."
+	@echo "  install    - Install the project using the built wheel package."
+	@echo "  uninstall  - Uninstall the project."
+	@echo "  clean      - Clean the project by removing build artifacts and Docker images."
+	@echo "  help       - Display this help message."

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ The Pantos Client CLI requires **Python 3.10**. Ensure that you have the correct
 Clone the repository to your local machine:
 
 ```bash
-$ git clone https://github.com/pantos-io/client-library.git
-$ cd client-library
+$ git clone https://github.com/pantos-io/client-cli.git
+$ cd client-cli
 $ git submodule init
 $ git submodule update --remote
 ```

--- a/pantos/client/cli/application.py
+++ b/pantos/client/cli/application.py
@@ -8,7 +8,7 @@ from pantos.client.cli.configuration import load_config
 
 
 def initialize_application() -> None:
-    """Intialize the client CLI application.
+    """Initialize the client CLI application.
 
     """
     logging.basicConfig(level=logging.WARNING)


### PR DESCRIPTION
Corrected the following:

* Corrected repository name. Instructions on 'README.md` file are wrong and are referring to repository `client-library` instead of `client-cli`. This makes anybody following the steps to run into an error and not finding the `pantos-client` file. Corrected it to the right name
* Typo in `application.py` file. 
* Improvements on the `Makefile`:  Added a help function so `make help` displays information to the user about the options they have. Currently:

```
$ make help
Available targets:
  dist       - Build both the wheel package and the Docker image.
  code       - Run checks, formatting, linting, sorting, security analysis, and tests.
  check      - Perform type checks on the code.
  format     - Format the codebase using yapf.
  lint       - Lint the codebase using flake8.
  sort       - Sort import statements using isort.
  bandit     - Perform security analysis using bandit.
  test       - Run tests using pytest.
  coverage   - Generate a test coverage report and remove the coverage file.
  wheel      - Build a wheel package for the project.
  docker     - Build a Docker image for the project.
  install    - Install the project using the built wheel package.
  uninstall  - Uninstall the project.
  clean      - Clean the project by removing build artifacts and Docker images.
  help       - Display this help message.
```
* Improvements on the `Makefile`: The current `Makefile` has multiple dependencies (like `docker`) and assumes the user has installed. If they are not install the process will fail abruptly. Now instead, it checks if the system has the dependencies it needs of a given target when a target is called. If the dependency is not installed it will inform the user to to so. For example:

```
Docker is not installed, please install it to continue
```
