### PR TITLE
PAN-2120: remove bid id

### DIFF
--- a/pantos/cli/__main__.py
+++ b/pantos/cli/__main__.py
@@ -264,8 +264,8 @@ def _print_bids(
     print('Pantos service node bids for token transfers from the\n'
           f'source blockchain {source_blockchain.name} to the destination '
           f'blockchain {destination_blockchain.name}:\n')  # noqa E231
-    print('Service node\t\t\t\t\tBid ID\tTime\tFee')
-    print('\t\t\t\t\t\t\t(s)\t(PAN)')
+    print('Service node\t\t\t\t\tTime\tFee')
+    print('\t\t\t\t\t\t(s)\t(PAN)')
     print('==================================='
           '==================================')
     for service_node_address, bids in service_node_bids.items():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pantos-client-cli"
-version = "1.1.2"
+version = "1.1.3"
 description = "Client CLI for engaging with the Pantos system"
 authors = ["Pantos GmbH <contact@pantos.io>"]
 license = "GPL-3.0-only"

--- a/tests/test__main__.py
+++ b/tests/test__main__.py
@@ -238,8 +238,8 @@ def test_bids(mock_retrieve_service_node_bids, mock_cli_config,
         'Pantos service node bids for token transfers from the\n'
         'source blockchain BNB_CHAIN to the destination blockchain ETHEREUM:\n'
         '\n'
-        'Service node\t\t\t\t\tBid ID\tTime\tFee\n'
-        '\t\t\t\t\t\t\t(s)\t(PAN)\n'
+        'Service node\t\t\t\t\tTime\tFee\n'
+        '\t\t\t\t\t\t(s)\t(PAN)\n'
         '===================================================================='
         '=\n0x9C20a03E230e9733561E4bab598409bB6d5AED12\t600\t2\n'
         '0x9C20a03E230e9733561E4bab598409bB6d5AED12\t1200\t1.5\n')
@@ -269,8 +269,8 @@ def test_bids_no_bids_available(mock_retrieve_service_node_bids,
         'Pantos service node bids for token transfers from the\n'
         'source blockchain BNB_CHAIN to the destination blockchain ETHEREUM:\n'
         '\n'
-        'Service node\t\t\t\t\tBid ID\tTime\tFee\n'
-        '\t\t\t\t\t\t\t(s)\t(PAN)\n'
+        'Service node\t\t\t\t\tTime\tFee\n'
+        '\t\t\t\t\t\t(s)\t(PAN)\n'
         '===================================================================='
         '=\n')
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
The Bid ID column has to be removed from the `bid` command output.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

NA

## QA Instructions

Run locally to check that output is correctly displayed:
````bash
python -m pantos.cli bids ethereum ethereum
/Users/XXXX/pantos/pantos-client-cli/env/lib/python3.12/site-packages/cerberus/validator.py:1674: UserWarning: No validation schema is defined for the arguments of rule 'one_not_present'
  warn(
Pantos service node bids for token transfers from the
source blockchain ETHEREUM to the destination blockchain ETHEREUM:

Service node                                    Time    Fee
                                                (s)     (PAN)
=====================================================================
0x9AbdAFA5b582Bd0A8A891bCA152674bb51176DE9      450     0.35
0x3fE3384286A7419b67031A4b4f49249AEEB02e26      5       0.2
0x726265A9e352F2e9f15F255957840992803cED7d      600     1
0xE25f1945fC38238dE7E3a9ab7106E8856cb3Ed4f      600     1
0x8529866eA10ECE785bBD0CAa78fCC0DaC13EAF63      10      246.36
0x8529866eA10ECE785bBD0CAa78fCC0DaC13EAF63      600     215.56
0x8529866eA10ECE785bBD0CAa78fCC0DaC13EAF63      1200    184.76
0x9e359AFd56be06cA6f389D0C552dB15f6948C62F      30      12
0x9e359AFd56be06cA6f389D0C552dB15f6948C62F      240     0.8
0x9e359AFd56be06cA6f389D0C552dB15f6948C62F      800     4
0x3432DefF56c3d6e1883d0A5c8243c11dA01257c8      5000    0.1
0x3432DefF56c3d6e1883d0A5c8243c11dA01257c8      6000    4.321
0x3432DefF56c3d6e1883d0A5c8243c11dA01257c8      4       4.321
````

## [optional] Are there any post deployment tasks we need to perform?
The warning message has to be addressed on a separate PR.